### PR TITLE
feat(properties): add create property and amenity

### DIFF
--- a/prisma/migrations/20250916012221_create_properties_amenities_and_property_amenities_tables/migration.sql
+++ b/prisma/migrations/20250916012221_create_properties_amenities_and_property_amenities_tables/migration.sql
@@ -1,0 +1,52 @@
+-- CreateEnum
+CREATE TYPE "public"."RefundPolicy" AS ENUM ('TOTAL', 'PARCIAL');
+
+-- AlterTable
+ALTER TABLE "public"."users" ALTER COLUMN "created_at" SET DEFAULT now(),
+ALTER COLUMN "updated_at" SET DEFAULT now();
+
+-- CreateTable
+CREATE TABLE "public"."properties" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "latitude" DECIMAL(65,30) NOT NULL,
+    "longitude" DECIMAL(65,30) NOT NULL,
+    "price_base" DECIMAL(65,30) NOT NULL,
+    "capacity" INTEGER NOT NULL,
+    "refund_policy" "public"."RefundPolicy" NOT NULL DEFAULT 'TOTAL',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "host_id" TEXT NOT NULL,
+
+    CONSTRAINT "properties_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."property_amenities" (
+    "property_id" TEXT NOT NULL,
+    "amenity_id" TEXT NOT NULL,
+
+    CONSTRAINT "property_amenities_pkey" PRIMARY KEY ("property_id","amenity_id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."amenities" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+
+    CONSTRAINT "amenities_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "amenities_title_key" ON "public"."amenities"("title");
+
+-- AddForeignKey
+ALTER TABLE "public"."properties" ADD CONSTRAINT "properties_host_id_fkey" FOREIGN KEY ("host_id") REFERENCES "public"."users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."property_amenities" ADD CONSTRAINT "property_amenities_property_id_fkey" FOREIGN KEY ("property_id") REFERENCES "public"."properties"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."property_amenities" ADD CONSTRAINT "property_amenities_amenity_id_fkey" FOREIGN KEY ("amenity_id") REFERENCES "public"."amenities"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,5 +23,51 @@ model User {
     created_at    DateTime @default(dbgenerated("now()"))
     updated_at    DateTime @default(dbgenerated("now()")) @updatedAt
 
+    property Property[]
+
     @@map("users")
+}
+
+enum RefundPolicy {
+    TOTAL
+    PARCIAL
+}
+
+model Property {
+    id            String       @id @default(nanoid())
+    title         String
+    description   String
+    latitude      Decimal
+    longitude     Decimal
+    price_base    Decimal
+    capacity      Int
+    refund_policy RefundPolicy @default(TOTAL)
+    created_at    DateTime     @default(now())
+    updated_at    DateTime     @default(now()) @updatedAt
+
+    host              User                @relation(fields: [host_id], references: [id])
+    host_id           String
+    PropertyToAmenity PropertyToAmenity[]
+
+    @@map("properties")
+}
+
+model PropertyToAmenity {
+    property_id String
+    amenity_id  String
+
+    property Property @relation(fields: [property_id], references: [id])
+    amenity  Amenity  @relation(fields: [amenity_id], references: [id])
+
+    @@id([property_id, amenity_id])
+    @@map("property_amenities")
+}
+
+model Amenity {
+    id                String              @id @default(uuid())
+    title             String              @unique
+    description       String?
+    PropertyToAmenity PropertyToAmenity[]
+
+    @@map("amenities")
 }

--- a/src/application/errors/AmenityAlreadyExistsError.ts
+++ b/src/application/errors/AmenityAlreadyExistsError.ts
@@ -1,0 +1,6 @@
+export class AmenityAlreadyExistsError extends Error {
+  constructor() {
+    super("Amenity already exists.");
+    this.name = "AmenityAlreadyExistsError";
+  }
+}

--- a/src/application/errors/ValueInvalidError.ts
+++ b/src/application/errors/ValueInvalidError.ts
@@ -1,0 +1,6 @@
+export class ValueInvalidError extends Error {
+  constructor(field: string) {
+    super(`Value invalid (${field}).`);
+    this.name = "ValueInvalidError";
+  }
+}

--- a/src/application/repositories/IAmenitiesRepository.ts
+++ b/src/application/repositories/IAmenitiesRepository.ts
@@ -1,0 +1,7 @@
+import type { Amenity } from "@/domain/entities/Amenity";
+import type { AmenityCreate } from "@/domain/entities/dto/AmenityCreate";
+
+export interface IAmenitiesRepository {
+  findByTitle(title: string): Promise<Amenity | null>;
+  create(data: AmenityCreate): Promise<Amenity>;
+}

--- a/src/application/repositories/IPropertiesRepository.ts
+++ b/src/application/repositories/IPropertiesRepository.ts
@@ -1,0 +1,6 @@
+import type { PropertyCreate } from "@/domain/entities/dto/PropertyCreate";
+import type { Property } from "@/domain/entities/Property";
+
+export interface IPropertiesRepository {
+  create(data: PropertyCreate): Promise<Property>;
+}

--- a/src/application/use-cases/amenities/CreateAmenityUseCase.ts
+++ b/src/application/use-cases/amenities/CreateAmenityUseCase.ts
@@ -1,0 +1,35 @@
+import { AmenityAlreadyExistsError } from "@/application/errors/AmenityAlreadyExistsError";
+import type { IAmenitiesRepository } from "@/application/repositories/IAmenitiesRepository";
+import type { Amenity } from "@/domain/entities/Amenity";
+
+type CreateAmenityRequest = {
+  title: string;
+  description: string | null;
+};
+
+type CreateAmenityResponse = {
+  amenity: Amenity;
+};
+
+export class CreateAmenityUseCase {
+  constructor(private readonly amenitiesRepository: IAmenitiesRepository) {}
+
+  async execute({
+    title,
+    description,
+  }: CreateAmenityRequest): Promise<CreateAmenityResponse> {
+    const amenityAlreadyExists =
+      await this.amenitiesRepository.findByTitle(title);
+
+    if (amenityAlreadyExists) {
+      throw new AmenityAlreadyExistsError();
+    }
+
+    const amenity = await this.amenitiesRepository.create({
+      title,
+      description,
+    });
+
+    return { amenity };
+  }
+}

--- a/src/application/use-cases/properties/CreatePropertyUseCase.ts
+++ b/src/application/use-cases/properties/CreatePropertyUseCase.ts
@@ -1,0 +1,40 @@
+import { ValueInvalidError } from "@/application/errors/ValueInvalidError";
+import type { IPropertiesRepository } from "@/application/repositories/IPropertiesRepository";
+import type { Property } from "@/domain/entities/Property";
+
+interface CreatePropertyRequest {
+  userId: string;
+  title: string;
+  description: string;
+  latitude: number;
+  longitude: number;
+  price_base: number;
+  capacity: number;
+  refund_policy: "TOTAL" | "PARCIAL";
+}
+
+interface CreatePropertyResponse {
+  property: Property;
+}
+
+export class CreatePropertyUseCase {
+  constructor(private readonly propertiesRepository: IPropertiesRepository) {}
+
+  async execute(data: CreatePropertyRequest): Promise<CreatePropertyResponse> {
+    if (data.price_base <= 0) {
+      throw new ValueInvalidError("Price Base");
+    }
+
+    if (data.capacity <= 0) {
+      throw new ValueInvalidError("Capacity");
+    }
+
+    const property = await this.propertiesRepository.create({
+      ...data,
+      host_id: data.userId,
+      amenities: [],
+    });
+
+    return { property };
+  }
+}

--- a/src/domain/entities/Amenity.ts
+++ b/src/domain/entities/Amenity.ts
@@ -1,0 +1,5 @@
+export interface Amenity {
+  id: string;
+  title: string;
+  description: string | null;
+}

--- a/src/domain/entities/Property.ts
+++ b/src/domain/entities/Property.ts
@@ -1,0 +1,13 @@
+export interface Property {
+  id: string;
+  title: string;
+  description: string;
+  latitude: number;
+  longitude: number;
+  price_base: number;
+  capacity: number;
+  refund_policy: "TOTAL" | "PARCIAL";
+  created_at: Date;
+  updated_at: Date;
+  host_id: string;
+}

--- a/src/domain/entities/dto/AmenityCreate.ts
+++ b/src/domain/entities/dto/AmenityCreate.ts
@@ -1,0 +1,4 @@
+export type AmenityCreate = {
+  title: string;
+  description: string | null;
+};

--- a/src/domain/entities/dto/PropertyCreate.ts
+++ b/src/domain/entities/dto/PropertyCreate.ts
@@ -1,0 +1,13 @@
+import type { Amenity } from "../Amenity";
+
+export type PropertyCreate = {
+  title: string;
+  description: string;
+  latitude: number;
+  longitude: number;
+  price_base: number;
+  capacity: number;
+  refund_policy: "TOTAL" | "PARCIAL";
+  host_id: string;
+  amenities: Amenity[];
+};

--- a/src/infrastructure/repositories/prisma/PrismaAmenitiesRepository.ts
+++ b/src/infrastructure/repositories/prisma/PrismaAmenitiesRepository.ts
@@ -1,0 +1,24 @@
+import type { IAmenitiesRepository } from "@/application/repositories/IAmenitiesRepository";
+import type { AmenityCreate } from "@/domain/entities/dto/AmenityCreate";
+import { prisma } from "@/infrastructure/prisma/client";
+
+export class PrismaAmenitiesRepository implements IAmenitiesRepository {
+  async findByTitle(title: string) {
+    return await prisma.amenity.findUnique({
+      where: {
+        title,
+      },
+    });
+  }
+
+  async create({ title, description }: AmenityCreate) {
+    const amenity = await prisma.amenity.create({
+      data: {
+        title,
+        description: description || "",
+      },
+    });
+
+    return amenity;
+  }
+}

--- a/src/infrastructure/repositories/prisma/PrismaPropertiesRepository.ts
+++ b/src/infrastructure/repositories/prisma/PrismaPropertiesRepository.ts
@@ -1,0 +1,28 @@
+import type { IPropertiesRepository } from "@/application/repositories/IPropertiesRepository";
+import type { PropertyCreate } from "@/domain/entities/dto/PropertyCreate";
+import { Decimal } from "@/generated/prisma/runtime/library";
+import { prisma } from "@/infrastructure/prisma/client";
+
+export class PrismaPropertiesRepository implements IPropertiesRepository {
+  async create(data: PropertyCreate) {
+    const property = await prisma.property.create({
+      data: {
+        title: data.title,
+        description: data.description,
+        capacity: data.capacity,
+        price_base: data.price_base,
+        refund_policy: data.refund_policy,
+        host_id: data.host_id,
+        latitude: new Decimal(data.latitude),
+        longitude: new Decimal(data.longitude),
+      },
+    });
+
+    return {
+      ...property,
+      latitude: data.latitude,
+      longitude: data.longitude,
+      price_base: data.price_base,
+    };
+  }
+}

--- a/src/tests/integrations/CreateAmenityUseCase.integration.spec.ts
+++ b/src/tests/integrations/CreateAmenityUseCase.integration.spec.ts
@@ -1,0 +1,50 @@
+import { AmenityAlreadyExistsError } from "@/application/errors/AmenityAlreadyExistsError";
+import type { IAmenitiesRepository } from "@/application/repositories/IAmenitiesRepository";
+import { CreateAmenityUseCase } from "@/application/use-cases/amenities/CreateAmenityUseCase";
+import { prisma } from "@/infrastructure/prisma/client";
+import { PrismaAmenitiesRepository } from "@/infrastructure/repositories/prisma/PrismaAmenitiesRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let amenitiesRepository: IAmenitiesRepository;
+let sut: CreateAmenityUseCase;
+
+describe("Create Amenity Use Case (Integration)", () => {
+  beforeEach(() => {
+    amenitiesRepository = new PrismaAmenitiesRepository();
+    sut = new CreateAmenityUseCase(amenitiesRepository);
+  });
+
+  afterEach(async () => {
+    await prisma.amenity.deleteMany();
+  });
+
+  it("Should be able to create an amenity", async () => {
+    const { amenity } = await sut.execute({
+      title: "Amenity 1",
+      description: "Amenity Description",
+    });
+
+    expect(amenity).toHaveProperty("id");
+    expect(amenity).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        title: "Amenity 1",
+        description: "Amenity Description",
+      }),
+    );
+  });
+
+  it("should not be able to create an amenity with same title", async () => {
+    await sut.execute({
+      title: "Amenity 1",
+      description: "Amenity Description",
+    });
+
+    await expect(() =>
+      sut.execute({
+        title: "Amenity 1",
+        description: "Amenity Description 2",
+      }),
+    ).rejects.toBeInstanceOf(AmenityAlreadyExistsError);
+  });
+});

--- a/src/tests/integrations/CreatePropertyUseCase.integration.spec.ts
+++ b/src/tests/integrations/CreatePropertyUseCase.integration.spec.ts
@@ -1,0 +1,93 @@
+import { ValueInvalidError } from "@/application/errors/ValueInvalidError";
+import type { IPropertiesRepository } from "@/application/repositories/IPropertiesRepository";
+import { CreatePropertyUseCase } from "@/application/use-cases/properties/CreatePropertyUseCase";
+import type { User } from "@/domain/entities/User";
+import { prisma } from "@/infrastructure/prisma/client";
+import { PrismaPropertiesRepository } from "@/infrastructure/repositories/prisma/PrismaPropertiesRepository";
+import { hash } from "bcryptjs";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+let propertiesRepository: IPropertiesRepository;
+let user: User;
+let sut: CreatePropertyUseCase;
+
+describe("Create Property Use Case (Integration)", () => {
+  beforeEach(() => {
+    propertiesRepository = new PrismaPropertiesRepository();
+    sut = new CreatePropertyUseCase(propertiesRepository);
+  });
+
+  beforeAll(async () => {
+    user = await prisma.user.create({
+      data: {
+        name: "John Doe",
+        email: "johndoe@example.com",
+        password_hash: await hash("123456", 6),
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await prisma.property.deleteMany();
+  });
+
+  it("Should be able to create a property", async () => {
+    const { property } = await sut.execute({
+      title: "House 1",
+      description: "House Description",
+      userId: user.id,
+      price_base: 250.5,
+      refund_policy: "TOTAL",
+      capacity: 8,
+      latitude: -47.854582,
+      longitude: -28.78475,
+    });
+
+    expect(property).toHaveProperty("id");
+    expect(property).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        title: "House 1",
+        description: "House Description",
+        host_id: user.id,
+        price_base: 250.5,
+        refund_policy: "TOTAL",
+        capacity: 8,
+        latitude: -47.854582,
+        longitude: -28.78475,
+        created_at: expect.any(Date),
+        updated_at: expect.any(Date),
+      }),
+    );
+  });
+
+  it("should not be able to create a property with price base less than or equal to 0", async () => {
+    await expect(() =>
+      sut.execute({
+        title: "House 1",
+        description: "House Description",
+        userId: user.id,
+        price_base: 0,
+        refund_policy: "TOTAL",
+        capacity: 8,
+        latitude: -47.854582,
+        longitude: -28.78475,
+      }),
+    ).rejects.toBeInstanceOf(ValueInvalidError);
+  });
+
+  it("should not be able to create a property with capacity less than or equal to 0", async () => {
+    await expect(() =>
+      sut.execute({
+        title: "House 1",
+        description: "House Description",
+        userId: user.id,
+        price_base: 250.5,
+        refund_policy: "TOTAL",
+        capacity: 0,
+        latitude: -47.854582,
+        longitude: -28.78475,
+      }),
+    ).rejects.toBeInstanceOf(ValueInvalidError);
+  });
+});

--- a/src/tests/units/CreateAmenityUseCase.unit.spec.ts
+++ b/src/tests/units/CreateAmenityUseCase.unit.spec.ts
@@ -1,0 +1,55 @@
+import { AmenityAlreadyExistsError } from "@/application/errors/AmenityAlreadyExistsError";
+import type { IAmenitiesRepository } from "@/application/repositories/IAmenitiesRepository";
+import { CreateAmenityUseCase } from "@/application/use-cases/amenities/CreateAmenityUseCase";
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+import { InMemoryAmenitiesRepository } from "./mocks/InMemoryAmenitiesRepository";
+
+let amenitiesRepository: IAmenitiesRepository;
+let sut: CreateAmenityUseCase;
+let spyCreate: MockInstance;
+
+describe("Create Amenity Use Case (Unit)", () => {
+  beforeEach(() => {
+    amenitiesRepository = new InMemoryAmenitiesRepository();
+    sut = new CreateAmenityUseCase(amenitiesRepository);
+
+    spyCreate = vi.spyOn(amenitiesRepository, "create");
+  });
+
+  it("Should be able to create an amenity", async () => {
+    const { amenity } = await sut.execute({
+      title: "Amenity 1",
+      description: "Amenity Description",
+    });
+
+    expect(amenity).toHaveProperty("id");
+    expect(amenity.id).toEqual(expect.any(String));
+    expect(spyCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Amenity 1",
+        description: "Amenity Description",
+      }),
+    );
+  });
+
+  it("should not be able to create an amenity with same title", async () => {
+    await sut.execute({
+      title: "Amenity 1",
+      description: "Amenity Description",
+    });
+
+    await expect(() =>
+      sut.execute({
+        title: "Amenity 1",
+        description: "Amenity Description 2",
+      }),
+    ).rejects.toBeInstanceOf(AmenityAlreadyExistsError);
+  });
+});

--- a/src/tests/units/CreatePropertyUseCase.unit.spec.ts
+++ b/src/tests/units/CreatePropertyUseCase.unit.spec.ts
@@ -1,0 +1,83 @@
+import { ValueInvalidError } from "@/application/errors/ValueInvalidError";
+import type { IPropertiesRepository } from "@/application/repositories/IPropertiesRepository";
+import { CreatePropertyUseCase } from "@/application/use-cases/properties/CreatePropertyUseCase";
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+import { InMemoryPropertiesRepository } from "./mocks/InMemoryPropertiesRepository";
+
+let propertiesRepository: IPropertiesRepository;
+let sut: CreatePropertyUseCase;
+let spyCreate: MockInstance;
+
+describe("Create Property Use Case (Unit)", () => {
+  beforeEach(() => {
+    propertiesRepository = new InMemoryPropertiesRepository();
+    sut = new CreatePropertyUseCase(propertiesRepository);
+
+    spyCreate = vi.spyOn(propertiesRepository, "create");
+  });
+
+  it("Should be able to create a property", async () => {
+    const { property } = await sut.execute({
+      title: "House 1",
+      description: "House Description",
+      userId: "user-1",
+      price_base: 250.5,
+      refund_policy: "TOTAL",
+      capacity: 8,
+      latitude: -47.854582,
+      longitude: -28.78475,
+    });
+
+    expect(property).toHaveProperty("id");
+    expect(property.id).toEqual(expect.any(String));
+    expect(spyCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "House 1",
+        description: "House Description",
+        userId: "user-1",
+        price_base: 250.5,
+        refund_policy: "TOTAL",
+        capacity: 8,
+        latitude: -47.854582,
+        longitude: -28.78475,
+      }),
+    );
+  });
+
+  it("should not be able to create a property with price base less than or equal to 0", async () => {
+    await expect(() =>
+      sut.execute({
+        title: "House 1",
+        description: "House Description",
+        userId: "user-1",
+        price_base: 0,
+        refund_policy: "TOTAL",
+        capacity: 8,
+        latitude: -47.854582,
+        longitude: -28.78475,
+      }),
+    ).rejects.toBeInstanceOf(ValueInvalidError);
+  });
+
+  it("should not be able to create a property with capacity less than or equal to 0", async () => {
+    await expect(() =>
+      sut.execute({
+        title: "House 1",
+        description: "House Description",
+        userId: "user-1",
+        price_base: 250.5,
+        refund_policy: "TOTAL",
+        capacity: 0,
+        latitude: -47.854582,
+        longitude: -28.78475,
+      }),
+    ).rejects.toBeInstanceOf(ValueInvalidError);
+  });
+});

--- a/src/tests/units/mocks/InMemoryAmenitiesRepository.ts
+++ b/src/tests/units/mocks/InMemoryAmenitiesRepository.ts
@@ -1,0 +1,24 @@
+import type { IAmenitiesRepository } from "@/application/repositories/IAmenitiesRepository";
+import type { Amenity } from "@/domain/entities/Amenity";
+import type { AmenityCreate } from "@/domain/entities/dto/AmenityCreate";
+import { randomUUID } from "crypto";
+
+export class InMemoryAmenitiesRepository implements IAmenitiesRepository {
+  private amenities: Amenity[] = [];
+
+  async findByTitle(title: string) {
+    return this.amenities.find((amenity) => amenity.title === title) || null;
+  }
+
+  async create(data: AmenityCreate) {
+    const amenityCreated: Amenity = {
+      id: randomUUID(),
+      title: data.title,
+      description: data.description || "",
+    };
+
+    this.amenities.push(amenityCreated);
+
+    return amenityCreated;
+  }
+}

--- a/src/tests/units/mocks/InMemoryPropertiesRepository.ts
+++ b/src/tests/units/mocks/InMemoryPropertiesRepository.ts
@@ -1,0 +1,28 @@
+import type { IPropertiesRepository } from "@/application/repositories/IPropertiesRepository";
+import type { PropertyCreate } from "@/domain/entities/dto/PropertyCreate";
+import type { Property } from "@/domain/entities/Property";
+import { randomUUID } from "crypto";
+
+export class InMemoryPropertiesRepository implements IPropertiesRepository {
+  private properties: Property[] = [];
+
+  async create(data: PropertyCreate) {
+    const propertyCreated: Property = {
+      id: randomUUID(),
+      title: data.title,
+      description: data.description,
+      latitude: data.latitude,
+      longitude: data.longitude,
+      host_id: data.host_id,
+      capacity: data.capacity,
+      price_base: data.price_base,
+      refund_policy: data.refund_policy,
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+
+    this.properties.push(propertyCreated);
+
+    return propertyCreated;
+  }
+}


### PR DESCRIPTION
## Adds Properties and Amenities features, including:

- Database: properties, amenities, and property_amenities tables.
- Domain: Property and Amenity entities.
- Application: CreatePropertyUseCase, CreateAmenityUseCase, AmenityAlreadyExistsError, ValueInvalidError.
- Infrastructure: Prisma repositories for properties and amenities.
- Tests: in-memory repositories, unit and integration tests for both use cases.

[x] Unit tests passing
[x] Integration tests passing